### PR TITLE
remove smtp config from Bitwarden

### DIFF
--- a/kubernetes/bitwarden/deployment.yaml
+++ b/kubernetes/bitwarden/deployment.yaml
@@ -49,27 +49,6 @@ spec:
                 secretKeyRef:
                   name: bitwarden-secrets
                   key: bw-installation-key
-            - name: globalSettings__mail__smtp__host
-              value: smtp.gmail.com
-            - name: globalSettings__mail__smtp__port
-              value: '587'
-            - name: globalSettings__mail__smtp__ssl
-              value: 'false'
-            - name: globalSettings__mail__replyToEmail
-              valueFrom:
-                secretKeyRef:
-                  name: bitwarden-secrets
-                  key: bw-reply-to-email
-            - name: globalSettings__mail__smtp__username
-              valueFrom:
-                secretKeyRef:
-                  name: bitwarden-secrets
-                  key: bw-smtp-username
-            - name: globalSettings__mail__smtp__password
-              valueFrom:
-                secretKeyRef:
-                  name: bitwarden-secrets
-                  key: bw-smtp-password
           volumeMounts:
             - mountPath: /etc/bitwarden
               name: bitwarden-pv

--- a/kubernetes/bitwarden/external-secrets.yaml
+++ b/kubernetes/bitwarden/external-secrets.yaml
@@ -15,12 +15,3 @@ spec:
     - secretKey: bw-installation-key
       remoteRef:
         key: /chroju/bitwarden/installtion-key
-    - secretKey: bw-reply-to-email
-      remoteRef:
-        key: /chroju/bitwarden/reply-to-email
-    - secretKey: bw-smtp-username
-      remoteRef:
-        key: /chroju/bitwarden/smtp-username
-    - secretKey: bw-smtp-password
-      remoteRef:
-        key: /chroju/bitwarden/smtp-password


### PR DESCRIPTION
The Bitwarden SMTP settings are no longer needed, so I'm removing them. They were previously essential for unlocking premium features.