### PR TITLE
chore(bitwarden): Update image tag to 2026.6.0

### DIFF
--- a/kubernetes/bitwarden/deployment.yaml
+++ b/kubernetes/bitwarden/deployment.yaml
@@ -16,7 +16,7 @@ spec:
         pod: bitwarden
     spec:
       containers:
-        - image: ghcr.io/bitwarden/self-host:2025.9.2-beta
+        - image: ghcr.io/bitwarden/self-host:2026.6.0
           name: bitwarden
           # livenessProbe:
           #   httpGet:


### PR DESCRIPTION
## Summary
- Bump Bitwarden self-host image from `2025.9.2-beta` to `2026.6.0`

## Changes
- `kubernetes/bitwarden/deployment.yaml`: update container image tag

## Test Plan
- ArgoCD will sync and redeploy the Bitwarden pod with the new image