### PR TITLE
fix(bitwarden): Fix image tag to use correct -beta suffix

### DIFF
--- a/kubernetes/bitwarden/deployment.yaml
+++ b/kubernetes/bitwarden/deployment.yaml
@@ -16,7 +16,7 @@ spec:
         pod: bitwarden
     spec:
       containers:
-        - image: ghcr.io/bitwarden/self-host:2026.6.0
+        - image: ghcr.io/bitwarden/self-host:2026.6.0-beta
           name: bitwarden
           # livenessProbe:
           #   httpGet:


### PR DESCRIPTION
## Summary
- Fix Bitwarden image tag from `2026.6.0` to `2026.6.0-beta`

## Changes
- `kubernetes/bitwarden/deployment.yaml`: correct container image tag

## Reason
The tag `ghcr.io/bitwarden/self-host:2026.6.0` does not exist, causing ArgoCD to fail with 403 Forbidden on image pull. The correct tag format has always included the `-beta` suffix (e.g. `2025.9.2-beta`).