### PR TITLE
ci: pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/terraform-apply.yaml
+++ b/.github/workflows/terraform-apply.yaml
@@ -34,7 +34,7 @@ jobs:
           echo "HEAD_REF=$HEAD_REF" >> $GITHUB_OUTPUT
           
       - name: Checkout
-        uses: actions/checkout@v4.3.0
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
         with:
           fetch-depth: 0
           ref: ${{ steps.pr-details.outputs.HEAD_REF }}
@@ -77,16 +77,16 @@ jobs:
           echo "HEAD_SHA=$HEAD_SHA" >> $GITHUB_OUTPUT
           
       - name: Checkout
-        uses: actions/checkout@v4.3.0
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
         with:
           fetch-depth: 0
           ref: ${{ steps.pr-details.outputs.HEAD_REF }}
 
       - name: Setup Terraform
-        uses: hashicorp/setup-terraform@v3.1.2
+        uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd # v3.1.2
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v4.3.1
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4.3.1
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
           aws-region: ap-northeast-1
@@ -127,7 +127,7 @@ jobs:
         continue-on-error: true
         
       - name: Update Pull Request
-        uses: actions/github-script@v7.1.0
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
         env:
           APPLY: "terraform\n${{ steps.apply.outputs.stdout }}"
           TERRAFORM_DIR: ${{ matrix.terraform_dir }}
@@ -156,7 +156,7 @@ jobs:
             })
             
       - name: Update Status Check
-        uses: actions/github-script@v7.1.0
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
         env:
           APPLY_EXIT_CODE: "${{ steps.apply.outputs.exitcode }}"
           TERRAFORM_DIR: "${{ matrix.terraform_dir }}"

--- a/.github/workflows/terraform-plan.yaml
+++ b/.github/workflows/terraform-plan.yaml
@@ -26,7 +26,7 @@ jobs:
       terraform_dirs: ${{ steps.set-dirs.outputs.terraform_dirs }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4.3.0
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
         with:
           fetch-depth: 0
           
@@ -69,13 +69,13 @@ jobs:
         terraform_dir: ${{ fromJson(needs.detect-terraform-dirs.outputs.terraform_dirs) }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4.3.0
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
 
       - name: Setup Terraform
-        uses: hashicorp/setup-terraform@v3.1.2
+        uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd # v3.1.2
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v4.3.1
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4.3.1
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
           aws-region: ap-northeast-1
@@ -121,7 +121,7 @@ jobs:
         continue-on-error: true
 
       - name: Update Pull Request
-        uses: actions/github-script@v7.1.0
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
         env:
           PLAN: "terraform\n${{ steps.plan.outputs.stdout }}"
           TERRAFORM_DIR: ${{ matrix.terraform_dir }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -3,15 +3,18 @@ name: ci
 on:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   docker:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Docker meta
         id: meta
-        uses: docker/metadata-action@v4
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
         with:
           images: name/app
           tags: |


### PR DESCRIPTION
## Summary

Pins all `uses:` references in GitHub Actions workflows to full commit SHAs (with trailing version comments) to protect against tag mutation and supply-chain attacks.

### terraform-apply.yaml / terraform-plan.yaml (versions unchanged, SHA-pinned)
- `actions/checkout@v4.3.0` -> `08eba0b27e820071cde6df949e0beb9ba4906955`
- `hashicorp/setup-terraform@v3.1.2` -> `b9cd54a3c349d3f38e8881555d616ced269862dd`
- `aws-actions/configure-aws-credentials@v4.3.1` -> `7474bc4690e29a8392af63c5b98e7449536d5c3a`
- `actions/github-script@v7.1.0` -> `f28e40c7f34bde8b3046d885e986cb6290c5673b`

### test.yaml (node16-deprecated majors upgraded and SHA-pinned)
- `actions/checkout@v3` -> `v6.0.2` (`de0fac2e4500dabe0009e67214ff5f5447ce83dd`)
- `docker/metadata-action@v4` -> `v6.2.0` (`dc802804100637a589fabce1cb79ff13a1411302`) — the existing `images:`/`tags:` inputs are unchanged across v5/v6, so no input adjustments were needed
- Added a top-level `permissions: contents: read` block

## Notes

- No behavioral changes intended for the Terraform workflows; their existing permissions blocks are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)